### PR TITLE
Updated the README's quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ yarn add @arcxmoney/analytics
 ```js
 const analytics = await ArcxAnalyticsSdk.init(YOUR_API_KEY)
 
-await analytics.connectWallet({account: '0x123', chain: 1})
+await analytics.attribute({ channel: 'twitter' })
+await analytics.connectWallet({ account: '0x123', chain: 1 })
 await analytics.transaction({
-  transactionType: 'SWAP', 
+  chain: 1, 
   transactionHash: '0xABC123', 
-  attributes: {
+  metadata: {
     usedSuggestedExchange: true
   }
 })


### PR DESCRIPTION
This was picked up by Index Coop's developers. Our quickstart guide was out of sync with our API.