### PR TITLE
Fixed the autotracker not submitting the correct event schema

### DIFF
--- a/src/ArcxAnalyticsSdk.ts
+++ b/src/ArcxAnalyticsSdk.ts
@@ -34,7 +34,7 @@ export class ArcxAnalyticsSdk {
         /* eslint-disable @typescript-eslint/no-explicit-any */
         if ((window as any).url !== location.href) {
           (window as any).url = location.href
-          this.page((window as any).url)
+          this.page({ url: (window as any).url })
         }
         /* eslint-enable @typescript-eslint/no-explicit-any */
       })


### PR DESCRIPTION
The `trackPagesChanges` method was submitting page events using the format `sdk.page(url)`. This is wrong. It should actually be using the format `sdk.page({ url })`. This PR addresses that issue and corrects the data structure going forward.